### PR TITLE
Python 3.x + Django 3+

### DIFF
--- a/passlib/ext/django/utils.py
+++ b/passlib/ext/django/utils.py
@@ -447,7 +447,7 @@ class DjangoContextAdapter(DjangoTranslator):
             self.get_user_category = get_user_category
 
         # install lru cache wrappers
-        from django.utils.lru_cache import lru_cache
+        from functools import lru_cache
         self.get_hashers = lru_cache()(self.get_hashers)
 
         # get copy of original make_password


### PR DESCRIPTION
fix ModuleNotFoundError: No module named 'django.utils.lru_cache'